### PR TITLE
Fix gas estimation

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -80,7 +80,7 @@ fc-cli = { workspace = true }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true }
 fc-mapping-sync = { workspace = true }
-fc-rpc = { workspace = true }
+fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"]}
 fc-rpc-core = { workspace = true }
 fc-storage = { workspace = true }
 fp-account = { workspace = true }


### PR DESCRIPTION
It looks like gas estimation in frontier is buggy by default. The implementation with binary search gas estimation (enabled by a cargo feature) doesn't have this issue. So the PR just enable the feature.