### PR TITLE
Add dispatch precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
+ "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
@@ -4836,6 +4837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5239,6 +5249,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5458,6 +5478,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-authorship"
@@ -5768,6 +5794,18 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+]
+
+[[package]]
+name = "pallet-evm-precompile-dispatch"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v1.8.0#064955a3a4cc2403e9d925ab60c11fd677d35058"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "pallet-evm",
+ "parity-scale-codec",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6213,9 +6251,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -6228,11 +6266,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6744,15 +6782,6 @@ checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -8564,8 +8593,8 @@ dependencies = [
  "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.8.0)",
  "thiserror",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-log 0.1.4",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -9297,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -9359,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9380,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9580,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9612,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "Inflector",
  "expander",
@@ -9705,7 +9734,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 
 [[package]]
 name = "sp-storage"
@@ -9723,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9754,18 +9783,18 @@ dependencies = [
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.8.0)",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -9860,13 +9889,11 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#b686bfefba9c9f18261d8cc0ff1afc055645d436"
+source = "git+https://github.com/paritytech/polkadot-sdk#a90d324d5b3252033e00a96d9f9f4890b1cfc982"
 dependencies = [
- "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "wasmtime",
 ]
 
 [[package]]
@@ -10595,17 +10622,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
@@ -10728,6 +10744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10746,7 +10773,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "parking_lot 0.11.2",
  "regex",
  "serde",
@@ -10756,8 +10783,26 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers 0.1.0",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ pallet-dynamic-fee = { git = "https://github.com/paritytech/frontier", branch = 
 pallet-ethereum = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }
 pallet-evm = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }
 pallet-evm-chain-id = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.8.0", default-features = false }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -85,7 +85,7 @@ pub fn testnet_config() -> ChainSpec {
     use testnet_keys::*;
 
     ChainSpec::builder(WASM_BINARY.expect("WASM not available"), Default::default())
-        .with_name("Testnet")
+        .with_name("Olympus")
         .with_id("testnet")
         .with_chain_type(ChainType::Custom("Testnet".to_string()))
         .with_properties(properties())

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -85,7 +85,7 @@ pub fn testnet_config() -> ChainSpec {
     use testnet_keys::*;
 
     ChainSpec::builder(WASM_BINARY.expect("WASM not available"), Default::default())
-        .with_name("Olympus")
+        .with_name("Olympia")
         .with_id("testnet")
         .with_chain_type(ChainType::Custom("Testnet".to_string()))
         .with_properties(properties())

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -84,6 +84,7 @@ pallet-evm-chain-id = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
+pallet-evm-precompile-dispatch = { workspace = true }
 pallet-hotfix-sufficients = { workspace = true }
 
 pallet-faucet = { workspace = true }
@@ -160,13 +161,14 @@ std = [
     "pallet-base-fee/std",
     "pallet-dynamic-fee/std",
     "pallet-ethereum/std",
-    "pallet-evm/std",
     "pallet-evm-chain-id/std",
+    "pallet-evm-precompile-dispatch/std",
     "pallet-evm-precompile-modexp/std",
     "pallet-evm-precompile-sha3fips/std",
     "pallet-evm-precompile-simple/std",
-    "pallet-hotfix-sufficients/std",
+    "pallet-evm/std",
     "pallet-faucet/std",
+    "pallet-hotfix-sufficients/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -225,7 +225,7 @@ parameter_types! {
         })
         .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
         .build_or_panic();
-    pub const SS58Prefix: u16 = 1603;
+    pub const SS58Prefix: u16 = 2340;
 }
 
 // Configure FRAME pallets to include in runtime.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -225,7 +225,7 @@ parameter_types! {
         })
         .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
         .build_or_panic();
-    pub const SS58Prefix: u16 = 2340;
+    pub const SS58Prefix: u16 = 1603;
 }
 
 // Configure FRAME pallets to include in runtime.

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -1,9 +1,13 @@
+use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{
     IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
+use parity_scale_codec::Decode;
 use sp_core::H160;
+use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 
+use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
@@ -17,13 +21,15 @@ where
     pub fn new() -> Self {
         Self(Default::default())
     }
-    pub fn used_addresses() -> [H160; 7] {
-        [hash(1), hash(2), hash(3), hash(4), hash(5), hash(1024), hash(1025)]
+    pub fn used_addresses() -> [H160; 8] {
+        [hash(1), hash(2), hash(3), hash(4), hash(5), hash(6), hash(1024), hash(1025)]
     }
 }
 impl<R> PrecompileSet for FrontierPrecompiles<R>
 where
     R: pallet_evm::Config,
+    R::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
+    <R::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<R::AccountId>>,
 {
     fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
         match handle.code_address() {
@@ -33,6 +39,7 @@ where
             a if a == hash(3) => Some(Ripemd160::execute(handle)),
             a if a == hash(4) => Some(Identity::execute(handle)),
             a if a == hash(5) => Some(Modexp::execute(handle)),
+            a if a == hash(6) => Some(Dispatch::<R>::execute(handle)),
             // Non-Frontier specific nor Ethereum precompiles :
             a if a == hash(1024) => Some(Sha3FIPS256::execute(handle)),
             a if a == hash(1025) => Some(ECRecoverPublicKey::execute(handle)),

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -1,16 +1,17 @@
-use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
+use frame_support::dispatch::{GetDispatchInfo, Pays};
 use pallet_evm::{
     IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
-use parity_scale_codec::Decode;
 use sp_core::H160;
-use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 
-use pallet_evm_precompile_dispatch::Dispatch;
+use pallet_evm::ExitError;
+use pallet_evm_precompile_dispatch::{Dispatch, DispatchValidateT};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
+
+use crate::*;
 
 pub struct FrontierPrecompiles<R>(PhantomData<R>);
 
@@ -22,14 +23,12 @@ where
         Self(Default::default())
     }
     pub fn used_addresses() -> [H160; 8] {
-        [hash(1), hash(2), hash(3), hash(4), hash(5), hash(6), hash(1024), hash(1025)]
+        [hash(1), hash(2), hash(3), hash(4), hash(5), hash(1024), hash(1025), hash(1026)]
     }
 }
 impl<R> PrecompileSet for FrontierPrecompiles<R>
 where
     R: pallet_evm::Config,
-    R::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
-    <R::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<R::AccountId>>,
 {
     fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
         match handle.code_address() {
@@ -39,10 +38,10 @@ where
             a if a == hash(3) => Some(Ripemd160::execute(handle)),
             a if a == hash(4) => Some(Identity::execute(handle)),
             a if a == hash(5) => Some(Modexp::execute(handle)),
-            a if a == hash(6) => Some(Dispatch::<R>::execute(handle)),
             // Non-Frontier specific nor Ethereum precompiles :
             a if a == hash(1024) => Some(Sha3FIPS256::execute(handle)),
             a if a == hash(1025) => Some(ECRecoverPublicKey::execute(handle)),
+            a if a == hash(1026) => Some(Dispatch::<Runtime, DispatchCallFilter>::execute(handle)),
             _ => None,
         }
     }
@@ -57,4 +56,37 @@ where
 
 fn hash(a: u64) -> H160 {
     H160::from_low_u64_be(a)
+}
+
+struct DispatchCallFilter;
+
+impl DispatchValidateT<AccountId, RuntimeCall> for DispatchCallFilter {
+    fn validate_before_dispatch(
+        _origin: &AccountId,
+        call: &RuntimeCall,
+    ) -> Option<fp_evm::PrecompileFailure> {
+        let info = call.get_dispatch_info();
+
+        if matches!(
+            call,
+            // we ALLOW dispatching these calls
+            RuntimeCall::Staking(..)
+                | RuntimeCall::Democracy(..)
+                | RuntimeCall::Elections(..)
+                | RuntimeCall::Preimage(..)
+                | RuntimeCall::NominationPools(..)
+        ) {
+            None
+        } else if info.pays_fee == Pays::No || info.class == DispatchClass::Mandatory {
+            Some(fp_evm::PrecompileFailure::Error {
+                exit_status: ExitError::Other("Permission denied calls".into()),
+            })
+        } else {
+            Some(fp_evm::PrecompileFailure::Error {
+                exit_status: ExitError::Other(
+                    "The call is not allowed to be dispatched via precompile.".into(),
+                ),
+            })
+        }
+    }
 }

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -78,6 +78,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DispatchCallFilter {
         ) {
             None
         } else if info.pays_fee == Pays::No || info.class == DispatchClass::Mandatory {
+            // forbid feeless and heavy calls to prevent spaming
             Some(fp_evm::PrecompileFailure::Error {
                 exit_status: ExitError::Other("Permission denied calls".into()),
             })

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# runs dev localy
+# runs local testnet (for devnet you can just `cargo run -- --dev`)
 # there will be 2 nodes:
 # 1. alice validator and bootnode
 # 2. bob validator
 
-cargo run -- --chain dev --force-authoring --rpc-cors=all --alice --tmp --node-key 0000000000000000000000000000000000000000000000000000000000000001 &
-    cargo run -- --chain dev --force-authoring --rpc-cors=all --bob --tmp --port 30334 --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
+cargo run -- --chain local --force-authoring --rpc-cors=all --alice --tmp --node-key 0000000000000000000000000000000000000000000000000000000000000001 &
+    cargo run -- --chain local --force-authoring --rpc-cors=all --bob --tmp --port 30334 --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp


### PR DESCRIPTION
This PR adds the [dispatch precompile](https://github.com/polkadot-evm/frontier/tree/master/frame/evm/precompile/dispatch), which allows to dispatch the runtime calls via a precompiled EVM smart contract. The precompile configured with a filter, which allows only calls from pallets:

- Staking;
- Democracy;
- Elections;
- Preimage;
- NominationPools.

It also changes "testnet" name to "olympia" and updates `run_locally` script to use `local testnet` chain spec, as we can run devnet with a single node and it's more convenient to use `cargo run -- --dev` in development.