### PR TITLE
fix: Updatede bootnode addresses for "mainnet" chainspec

### DIFF
--- a/chainspecs/chain-spec.mainnet.json
+++ b/chainspecs/chain-spec.mainnet.json
@@ -3,8 +3,10 @@
   "id": "mainnet",
   "chainType": "Live",
   "bootNodes": [
-    "/dns/bootnode-0.atleta.network/tcp/30333/ws/p2p/12D3KooWKaJPoiKoXMunjuALpEj2xSViE2Q1MDZUuuPN9pc4T1VN",
-    "/dns/bootnode-1.atleta.network/tcp/30333/ws/p2p/12D3KooWSfdb4Fv5BRt3P6PuYUBm7F1tK65PTvWDU4FaLq55499c"
+    "/dns/bootnode-0.atleta.network/tcp/30333/p2p/12D3KooWKaJPoiKoXMunjuALpEj2xSViE2Q1MDZUuuPN9pc4T1VN",
+    "/dns/bootnode-0.atleta.network/tcp/30334/ws/p2p/12D3KooWKaJPoiKoXMunjuALpEj2xSViE2Q1MDZUuuPN9pc4T1VN",
+    "/dns/bootnode-1.atleta.network/tcp/30333/p2p/12D3KooWSfdb4Fv5BRt3P6PuYUBm7F1tK65PTvWDU4FaLq55499c",
+    "/dns/bootnode-1.atleta.network/tcp/30334/ws/p2p/12D3KooWSfdb4Fv5BRt3P6PuYUBm7F1tK65PTvWDU4FaLq55499c"
   ],
   "telemetryEndpoints": [
      ["wss://telemetry.atleta.network/submit", 1]


### PR DESCRIPTION
## Description

 Unfortunately was a small mistake from my side by specifying wrong bootnode WebSocket port for `mainnet` chainspec. Also have added the standard P2P address.

 Summary:
 - Fixed bootnode addresses in chainspec.

## Type of change

 Please delete options that are not relevant.

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update

## How Has This Been Tested?

 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 - [ ] Test A - Run the code locally with `dry-run` mode;
 - [ ] Test B - Run the code on `devnet` environment;
 - [ ] Test C - ...

## Notes

 If you want to left some extra comment please type it here.